### PR TITLE
Major refactor

### DIFF
--- a/python/fancystft.py
+++ b/python/fancystft.py
@@ -6,10 +6,12 @@
 #
 # Licence: CC BY-SA 3.0 US
 
-
 import numpy as np
-import scipy.signal
+import scipy.interpolate
 import scipy.io.wavfile
+import scipy.signal
+
+rng = np.random.default_rng()
 
 topWindow = 256
 nBands = 9
@@ -60,6 +62,40 @@ def interp_stft(Zxx, n):
     Zxx_interp = p2i(Zxx_mag_interp, Zxx_phase_interp)
     #print(Zxx[10,:4], Zxx_interp[10,:16])
     return Zxx_interp
+
+def randomize_phase(z):
+    '''Takes a complex number, randomizes its phase while retaining its amplitude'''
+    amp = np.abs(z)
+    theta = rng.random() * np.pi * 2
+    return amp * np.exp(1j*theta)
+
+def fd_bandpass(Zxx, low_stft_bin, high_stft_bin):
+    '''Does a frequency domain brickwall bandpass filter on an STFT array
+    from low_stft_bin to high_stft_bin'''
+    Zxx[:low_stft_bin] = 0
+    Zxx[high_stft_bin:] = 0
+    return Zxx
+
+def filter_and_scramble(Zxx, low_stft_bin, high_stft_bin):
+    '''Takes a complex number, randomizes its phase while retaining its amplitude'''
+    randomize_phase_vectorized = np.vectorize(randomize_phase)
+    Zxx[:low_stft_bin] = 0
+    Zxx[low_stft_bin:high_stft_bin] = randomize_phase_vectorized(Zxx[low_stft_bin:high_stft_bin])
+    Zxx[high_stft_bin:] = 0
+    return Zxx
+
+
+def fancy_stretch(x):
+    out_unmixed = []
+    for nfft, noverlap, (lowSTFTBin, highSTFTBin) in zip(nffts, noverlaps, STFTBins):
+        print(f'running for size {nfft}')
+        _, _, Zxx = scipy.signal.stft(x, nfft=nfft, noverlap=noverlap, nperseg=nfft)
+        Zxx_filtered_and_scrambled = filter_and_scramble(Zxx, lowSTFTBin, highSTFTBin)
+        _, x = scipy.signal.istft(Zxx_filtered_and_scrambled, nfft=nfft, noverlap=noverlap, nperseg=nfft)
+        out_unmixed.append(x)
+    lengths = [len(x) for x in out_unmixed]
+    print(f'out_unmixed has {len(out_unmixed)} channels with lengths of {lengths}')
+
 
 def fstft(x, fs):
     '''Fancy multiresulotion STFT.
@@ -149,3 +185,53 @@ def demo(audioInputPath, autioOutputPath):
 
 
 #demo('sources/charli-xcx_blame_L.wav', 'output/charli-xcx_blame_fstft.wav')
+
+class AnalysisBand(object):
+    def __init__(self, nfft=None, hop_size=None, freqs=None, times=None, zxx=None, window=None):
+        self.nfft = nfft
+        self.hop_size = hop_size
+        self.freqs = freqs
+        self.times = times
+        self.window = window
+        self.amplitudes = np.abs(zxx)
+
+def analyze_band(input_signal, nfft, overlap, window='hann'):
+    hop_size = nfft // overlap
+    noverlap = nfft - hop_size
+    freqs, times, zxx = scipy.signal.stft(input_signal, nperseg=nfft, noverlap=noverlap, window=window)
+    return AnalysisBand(nfft=nfft, hop_size=hop_size, freqs=freqs, times=times, zxx=zxx, window=window)
+
+def analyze(input_signal, overlap, window='hann'):
+    analysis = {}
+    for nfft in nffts:
+        print(f'running for size {nfft}')
+        analysis[nfft] = analyze_band(input_signal, nfft, overlap, window=window)
+    return analysis
+
+def bandpass_filter_impulse(fft_size, low_bin, high_bin):
+    return np.concatenate([np.zeros(low_bin), np.ones(1 + high_bin - low_bin), np.zeros(fft_size - high_bin - 1)])
+
+def synthesize_frame(frame_amplitudes, filter_impulse, window_array):
+    # TODO: only make random phases for bins we're going to use
+    phases = np.random.uniform(0, 2*np.pi, frame_amplitudes.shape) * 1j
+    frame = frame_amplitudes * np.exp(phases) * filter_impulse
+    frame_output = scipy.fft.irfft(frame) * window_array
+    return frame_output
+
+def synthesize_band(band, playback_rate):
+    band_output = np.array([])
+    window_array = scipy.signal.get_window(band.window, band.nfft)
+    filter_impulse = bandpass_filter_impulse(band.nfft, low_bin, high_bin)
+    interp_func = scipy.interpolate.interp1d(band.times, band.amplitudes)
+    last_time_in_source = band.times[-1]
+    target_length = last_time_in_source / playback_rate
+    hop_size = band.hop_size
+    cur_output_time = 0
+    while cur_output_time < target_length:
+        source_time = cur_output_time * playback_rate
+        frame_amplitudes = interp_func(source_time)
+        frame_output = synthesize_frame(frame_amplitudes, filter_impulse, window_array)
+        np.append(band_output, np.zeros(hop_size))
+        band_output[cur_output_time:(cur_output_time + hop_size)] += frame_output
+        cur_output_time += hop_size
+    return band_output

--- a/python/fancystft.py
+++ b/python/fancystft.py
@@ -98,6 +98,7 @@ def fancy_stretch(input_signal, playback_rate, overlap=4, window='hann'):
         low_bin, high_bin = fancy_bands[nfft]
         print(f'running synthesis for size {nfft}')
         band_outputs[nfft] = synthesize_band(analysis_band, low_bin, high_bin, playback_rate)
+    print('mixing bands')
     max_length = max([len(band_output) for band_output in band_outputs.values()])
     zeros = np.zeros(max_length)
     mix_bus = np.copy(zeros)

--- a/python/fancystft.py
+++ b/python/fancystft.py
@@ -3,188 +3,27 @@
 # Fancy STFT
 #
 # by Alex Ness (asness@gmail.com)
+# and Jem Altieri (jem@jem.space)
 #
 # Licence: CC BY-SA 3.0 US
 
+from functools import reduce
 import numpy as np
 import scipy.interpolate
 import scipy.io.wavfile
 import scipy.signal
 
-rng = np.random.default_rng()
-
-topWindow = 256
-nBands = 9
-nffts = [topWindow * pow(2, i) for i in range(nBands)]
-binsPerBand = topWindow // 4
-hops = [nfft // 4 for nfft in nffts]
-noverlaps = [nfft - hop for nfft, hop in zip(nffts, hops)]
-
-# higher bins contain more time data than lower bins,
-# but we want all the time data in the same array:
-# duplicate (repeat) samples in the lower bins
-repeatFactors = [pow(2, n) for n in range(nBands)]
-
-# where the frequencies live in the STFT
-# special sauce for the low frequencies: use all bins below threshold
-STFTBins = [(0, topWindow // 2 + 1)]
-# use a fixed range of bins for the other frequencies
-bottomBin = topWindow // 4 + 1
-topBin = topWindow // 2 + 1 # includes adding one for range arguments
-STFTBins += [(bottomBin, topBin) for i in range(nBands - 1)]
-# list high frequency bins first (to make consistent with the lists above)
-STFTBins = list(reversed(STFTBins))
-
-# where the frequencies live in the FSTFT
-# includes special sauce for the low frequencies
-FSTFTBins = [(0, 2*binsPerBand + 1)]
-FSTFTBins += [((n+2)*binsPerBand + 1, (n+3)*binsPerBand + 1) for n in range(nBands - 1)]
-# list high frequencies first
-FSTFTBins = list(reversed(FSTFTBins))
-
-def p2i(r, th):
-    th_norm = th % (2*np.pi)
-    return r * np.exp(1j * th_norm)
-
-def interp_stft(Zxx, n):
-    '''Interpolate STFT data.
-    Smaller n values mean more interpolation (more time samples).'''
-    Zxx_freqs, Zxx_frames = Zxx.shape
-    Zxx_mag = np.abs(Zxx)
-    Zxx_phase = np.unwrap(np.angle(Zxx))
-
-    magInterpFunc = scipy.interpolate.interp2d(range(Zxx_frames), range(Zxx_freqs), Zxx_mag, kind='cubic')
-    Zxx_mag_interp = magInterpFunc(np.arange(0, Zxx_frames, n), range(Zxx_freqs))
-
-    phaseInterpFunc = scipy.interpolate.interp2d(range(Zxx_frames), range(Zxx_freqs), Zxx_phase, kind='cubic')
-    Zxx_phase_interp = phaseInterpFunc(np.arange(0, Zxx_frames, n), range(Zxx_freqs))
-
-    Zxx_interp = p2i(Zxx_mag_interp, Zxx_phase_interp)
-    #print(Zxx[10,:4], Zxx_interp[10,:16])
-    return Zxx_interp
-
-def randomize_phase(z):
-    '''Takes a complex number, randomizes its phase while retaining its amplitude'''
-    amp = np.abs(z)
-    theta = rng.random() * np.pi * 2
-    return amp * np.exp(1j*theta)
-
-def fd_bandpass(Zxx, low_stft_bin, high_stft_bin):
-    '''Does a frequency domain brickwall bandpass filter on an STFT array
-    from low_stft_bin to high_stft_bin'''
-    Zxx[:low_stft_bin] = 0
-    Zxx[high_stft_bin:] = 0
-    return Zxx
-
-def filter_and_scramble(Zxx, low_stft_bin, high_stft_bin):
-    '''Takes a complex number, randomizes its phase while retaining its amplitude'''
-    randomize_phase_vectorized = np.vectorize(randomize_phase)
-    Zxx[:low_stft_bin] = 0
-    Zxx[low_stft_bin:high_stft_bin] = randomize_phase_vectorized(Zxx[low_stft_bin:high_stft_bin])
-    Zxx[high_stft_bin:] = 0
-    return Zxx
-
-
-def fancy_stretch(x):
-    out_unmixed = []
-    for nfft, noverlap, (lowSTFTBin, highSTFTBin) in zip(nffts, noverlaps, STFTBins):
-        print(f'running for size {nfft}')
-        _, _, Zxx = scipy.signal.stft(x, nfft=nfft, noverlap=noverlap, nperseg=nfft)
-        Zxx_filtered_and_scrambled = filter_and_scramble(Zxx, lowSTFTBin, highSTFTBin)
-        _, x = scipy.signal.istft(Zxx_filtered_and_scrambled, nfft=nfft, noverlap=noverlap, nperseg=nfft)
-        out_unmixed.append(x)
-    lengths = [len(x) for x in out_unmixed]
-    print(f'out_unmixed has {len(out_unmixed)} channels with lengths of {lengths}')
-
-
-def fstft(x, fs):
-    '''Fancy multiresulotion STFT.
-    x is a 1D array of audio sample data.'''
-
-    Zxx_sum = None
-    numFrames = None
-    freqs = None
-    times = None
-
-    print('Fancy STFT in progress.')
-    for nfft, noverlap, rf, (lowSTFTBin, highSTFTBin) in zip(nffts, noverlaps, repeatFactors, STFTBins):
-        f, t, Zxx = scipy.signal.stft(x, nfft=nfft, fs=fs, noverlap=noverlap, nperseg=nfft)
-        print('nfft : %d, noverlap: %d, Zxx.shape: %s' % (nfft, noverlap, str(Zxx.shape)))
-        # append some frequency data
-        if freqs is None:
-            freqs = f[lowSTFTBin:highSTFTBin]
-        else:
-            freqs = np.insert(freqs, 0, f[lowSTFTBin:highSTFTBin])
-
-        if times is None:
-            times = t
-
-        # crop the bins
-        Zxx_cropped = Zxx[lowSTFTBin:highSTFTBin,:]
-
-        # add a range of bins from the current STFT to the start (bottom)
-        # of the output array
-
-        if Zxx_sum is None:
-            Zxx_sum = Zxx_cropped
-            numFreqs, numFrames = Zxx_sum.shape
-        else:
-            # interpolate, don't repeat!
-            #Zxx_interp = np.repeat(Zxx_cropped, rf, axis=1)
-            # (otherwise time-stretching sounds chunky)
-            Zxx_interp = interp_stft(Zxx_cropped, 1.0/rf)
-            Zxx_recropped = Zxx_interp[:,:numFrames]
-            Zxx_sum = np.insert(Zxx_sum, 0, Zxx_recropped, axis=0)
-    return freqs, times, Zxx_sum
-
-def ifstft(Zxx_sum):
-    '''Fancy multiresolution ISTFT.
-    Zxx_sum is an FSTFT.'''
-
-    print('Fancy ISTFT in progress.')
-    x_sum = None
-
-    for nfft, noverlap, rf, (lowSTFTBin, highSTFTBin), (lowFSTFTBin, highFSTFTBin) in zip(nffts, noverlaps, repeatFactors, STFTBins, FSTFTBins):
-
-        # extract STFT bins and decimate frames
-        Zxx = Zxx_sum[lowFSTFTBin:highFSTFTBin,::rf]
-        numBins, numFrames = Zxx.shape
-
-        # create an empty STFT of the appropriate size
-        Zxx_pad = np.zeros((nfft//2 + 1, numFrames), dtype='complex128')
-        print('nfft : %d, noverlap: %d, Zxx_pad.shape: %s' % (nfft, noverlap, str(Zxx_pad.shape)))
-
-        # paste in the appropriate FSTFT bins
-        Zxx_pad[lowSTFTBin:highSTFTBin] += Zxx
-
-        # take the ISTFT with the given overlap
-        t, x = scipy.signal.istft(Zxx_pad, nfft=nfft, noverlap=noverlap, nperseg=nfft)
-
-        if x_sum is None:
-            x_sum = x
-        else:
-            x_sum[:len(x)] += x
-    return x_sum
-
-def demo(audioInputPath, autioOutputPath):
-    '''Use a mono audio file.'''
-
-    # load an audio file as an array
-    rate, data = scipy.io.wavfile.read(audioInputPath)
-
-    # scale the audio data to [-1.0, 1.0]
-    scale = pow(2, 15) # assume 16 bit audio
-    data_float = data / float(scale)
-
-    freqs, times, Zxx = fstft(data_float, rate)
-    #print(freqs)
-
-    x = ifstft(Zxx)
-    print('writing audio. . .')
-    scipy.io.wavfile.write(autioOutputPath, rate, np.int16(x*scale))
-
-
-#demo('sources/charli-xcx_blame_L.wav', 'output/charli-xcx_blame_fstft.wav')
+fancy_bands = {
+    256: (65, 128),
+    512: (65, 129),
+    1024: (65, 129),
+    2048: (65, 129),
+    4096: (65, 129),
+    8192: (65, 129),
+    16384: (65, 129),
+    32768: (65, 129),
+    65536: (0, 129),
+    }
 
 class AnalysisBand(object):
     def __init__(self, nfft=None, hop_size=None, freqs=None, times=None, zxx=None, window=None):
@@ -193,45 +32,79 @@ class AnalysisBand(object):
         self.freqs = freqs
         self.times = times
         self.window = window
+        self.frame_size = len(freqs)
         self.amplitudes = np.abs(zxx)
 
 def analyze_band(input_signal, nfft, overlap, window='hann'):
+    # print(f"nfft = {nfft}")
     hop_size = nfft // overlap
     noverlap = nfft - hop_size
     freqs, times, zxx = scipy.signal.stft(input_signal, nperseg=nfft, noverlap=noverlap, window=window)
+    # print(f"analyze band zxx shape {zxx.shape}")
     return AnalysisBand(nfft=nfft, hop_size=hop_size, freqs=freqs, times=times, zxx=zxx, window=window)
 
-def analyze(input_signal, overlap, window='hann'):
+def analyze(input_signal, overlap, nffts, window='hann'):
     analysis = {}
     for nfft in nffts:
-        print(f'running for size {nfft}')
+        print(f'running analysis for size {nfft}')
         analysis[nfft] = analyze_band(input_signal, nfft, overlap, window=window)
     return analysis
 
-def bandpass_filter_impulse(fft_size, low_bin, high_bin):
-    return np.concatenate([np.zeros(low_bin), np.ones(1 + high_bin - low_bin), np.zeros(fft_size - high_bin - 1)])
+def bandpass_filter_impulse(frame_size, low_bin, high_bin):
+    return np.concatenate([np.zeros(low_bin), np.ones(1 + high_bin - low_bin), np.zeros(frame_size - high_bin - 1)])
 
 def synthesize_frame(frame_amplitudes, filter_impulse, window_array):
     # TODO: only make random phases for bins we're going to use
     phases = np.random.uniform(0, 2*np.pi, frame_amplitudes.shape) * 1j
+    # print(frame_amplitudes.shape)
+    # print(filter_impulse.shape)
+    # print(window_array.shape)
     frame = frame_amplitudes * np.exp(phases) * filter_impulse
+    foo = scipy.fft.irfft(frame)
+    # print(foo.shape)
     frame_output = scipy.fft.irfft(frame) * window_array
     return frame_output
 
-def synthesize_band(band, playback_rate):
-    band_output = np.array([])
+def synthesize_band(band, low_bin, high_bin, playback_rate):
+    # print(f"band shape: {band.amplitudes.shape}")
     window_array = scipy.signal.get_window(band.window, band.nfft)
-    filter_impulse = bandpass_filter_impulse(band.nfft, low_bin, high_bin)
+    filter_impulse = bandpass_filter_impulse(band.frame_size, low_bin, high_bin)
     interp_func = scipy.interpolate.interp1d(band.times, band.amplitudes)
     last_time_in_source = band.times[-1]
     target_length = last_time_in_source / playback_rate
     hop_size = band.hop_size
     cur_output_time = 0
+    # print(f"target_length: {target_length}")
+    frames_processed = 0
+    band_output = np.zeros(int(target_length) + band.nfft)
     while cur_output_time < target_length:
         source_time = cur_output_time * playback_rate
         frame_amplitudes = interp_func(source_time)
         frame_output = synthesize_frame(frame_amplitudes, filter_impulse, window_array)
-        np.append(band_output, np.zeros(hop_size))
-        band_output[cur_output_time:(cur_output_time + hop_size)] += frame_output
+        # print(frame_output.shape)
+        # print(f"frame output shape: {frame_output.shape}")
+        # print(f"target region shape: {band_output[cur_output_time:(cur_output_time + frame_output.shape[0])].shape}")
+        band_output[cur_output_time:(cur_output_time + len(frame_output))] += frame_output
         cur_output_time += hop_size
+        # frames_processed += 1
+        # print(f"cur_output_time: {cur_output_time}")
+        # if (frames_processed % 100 == 0):
+        #     pct_done = cur_output_time / target_length
+        #     print(f"percent done: {pct_done}")
     return band_output
+
+def fancy_stretch(input_signal, playback_rate, overlap=4):
+    band_outputs = {}
+    analysis = analyze(input_signal, overlap, fancy_bands.keys(), window='hann')
+    for nfft, analysis_band in analysis.items():
+        low_bin, high_bin = fancy_bands[nfft]
+        print(f'running synthesis for size {nfft}')
+        band_outputs[nfft] = synthesize_band(analysis_band, low_bin, high_bin, playback_rate)
+    max_length = max([len(band_output) for band_output in band_outputs.values()])
+    zeros = np.zeros(max_length)
+    mix_bus = np.copy(zeros)
+    for band_output in band_outputs.values():
+        temp = np.copy(zeros)
+        temp[0:len(band_output)] = band_output
+        mix_bus += temp
+    return mix_bus

--- a/python/nessstretch.py
+++ b/python/nessstretch.py
@@ -10,7 +10,7 @@ import argparse
 from os.path import join
 import numpy as np
 import scipy
-from fancystft import fstft, ifstft # fancy STFT
+from fancystft import fstft, ifstft, fancy_stretch # fancy STFT
 
 DEFAULT_RATE_NUMERATOR = 1
 DEFAULT_RATE_DENOMINATOR = 8
@@ -37,6 +37,10 @@ def render(infile, outfile, playback_rate):
     for channel in range(n_channels):
         print(f'processing channel {channel+1}')
         input_channel = normalized_input_data[:, channel]
+        output = fancy_stretch(input_channel)
+        exit()
+
+
 
         f, t, Zxx = fstft(input_channel, input_sample_rate)
         print('separating magnitude and phase. . .')

--- a/python/nessstretch.py
+++ b/python/nessstretch.py
@@ -10,14 +10,10 @@ import argparse
 from os.path import join
 import numpy as np
 import scipy
-from fancystft import fstft, ifstft, fancy_stretch # fancy STFT
+from fancystft import fancy_stretch
 
 DEFAULT_RATE_NUMERATOR = 1
-DEFAULT_RATE_DENOMINATOR = 8
-
-def random_phases(Zxx):
-    '''Zxx is a time-stretched STFT'''
-    return np.exp(2 * np.pi * 1.j * np.random.rand(*Zxx.shape))
+DEFAULT_RATE_DENOMINATOR = 2
 
 def render(infile, outfile, playback_rate):
     print(f'loading input file {infile.name}')
@@ -37,28 +33,7 @@ def render(infile, outfile, playback_rate):
     for channel in range(n_channels):
         print(f'processing channel {channel+1}')
         input_channel = normalized_input_data[:, channel]
-        output = fancy_stretch(input_channel)
-        exit()
-
-
-
-        f, t, Zxx = fstft(input_channel, input_sample_rate)
-        print('separating magnitude and phase. . .')
-        Zxx_mag = np.abs(Zxx)
-        freqs, frames = Zxx.shape
-
-        print('interpolating. . .')
-        interpFunc = scipy.interpolate.interp2d(range(frames), range(freqs), Zxx_mag, kind='linear')
-        Zxx_stretched = interpFunc(np.arange(0, frames, playback_rate), range(freqs))
-
-        # generate separate random phases for each channel
-        print('generating random phases. . . ')
-        Zxx_phases = random_phases(Zxx_stretched)
-
-        print('randomizing STFT phases. . .')
-        Zxx_random = Zxx_phases * Zxx_stretched
-
-        output.append(ifstft(Zxx_random))
+        output = fancy_stretch(input_channel, playback_rate)
 
     print('creating audio array. . .')
 

--- a/python/nessstretch.py
+++ b/python/nessstretch.py
@@ -13,7 +13,7 @@ import scipy
 from fancystft import fancy_stretch
 
 DEFAULT_RATE_NUMERATOR = 1
-DEFAULT_RATE_DENOMINATOR = 2
+DEFAULT_RATE_DENOMINATOR = 8
 
 def render(infile, outfile, playback_rate):
     print(f'loading input file {infile.name}')

--- a/python/nessstretch.py
+++ b/python/nessstretch.py
@@ -3,6 +3,7 @@
 # Time stretch with fancy STFT
 #
 # by Alex Ness (asness@gmail.com)
+# and Jem Altieri (jem@jem.space)
 #
 # Licence: CC BY-SA 3.0 US
 
@@ -14,8 +15,24 @@ from fancystft import fancy_stretch
 
 DEFAULT_RATE_NUMERATOR = 1
 DEFAULT_RATE_DENOMINATOR = 8
+DEFAULT_OVERLAP = 4
+WINDOW_TYPES = [
+    'boxcar',
+    'triang',
+    'blackman',
+    'hamming',
+    'hann',
+    'bartlett',
+    'flattop',
+    'parzen',
+    'bohman',
+    'blackmanharris',
+    'nuttall',
+    'barthann',
+]
+DEFAULT_WINDOW = 'hann'
 
-def render(infile, outfile, playback_rate):
+def render(infile, outfile, playback_rate, overlap, window):
     print(f'loading input file {infile.name}')
     input_sample_rate, raw_input_data = scipy.io.wavfile.read(infile)
     n_input_frames, n_channels = raw_input_data.shape
@@ -24,30 +41,23 @@ def render(infile, outfile, playback_rate):
     print(f'Input frames: {n_input_frames}')
     print(f'Input sample type: {input_dtype}')
     print(f'Input sample rate: {input_sample_rate}')
-
     # TODO: handle float input
     max_dtype_val = np.iinfo(input_dtype).max
     normalized_input_data = raw_input_data / max_dtype_val
-
     output = []
     for channel in range(n_channels):
         print(f'processing channel {channel+1}')
         input_channel = normalized_input_data[:, channel]
-        output = fancy_stretch(input_channel, playback_rate)
-
-    print('creating audio array. . .')
-
+        output = fancy_stretch(input_channel, playback_rate, overlap=overlap, window=window)
     # Transpose array: see https://github.com/bastibe/SoundFile/issues/203
     audio_array = np.int16(np.array(output).T * max_dtype_val)
-
     print('writing audio. . .')
     scipy.io.wavfile.write(outfile, input_sample_rate, audio_array)
     print(f'output file path is {args.outfile.name}')
 
-
 def perform_stretch(args):
     playback_rate = args.rate_numerator / args.rate_denominator
-    render(args.infile, args.outfile, playback_rate)
+    render(args.infile, args.outfile, playback_rate, args.overlap, args.window)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -63,5 +73,15 @@ if __name__ == "__main__":
         type=float,
         default=DEFAULT_RATE_DENOMINATOR,
         help=f'denominator of the playback rate ratio, default is {DEFAULT_RATE_DENOMINATOR}')
+    parser.add_argument(
+        '-v', '--overlap',
+        choices=[2,4,8],
+        default=DEFAULT_OVERLAP,
+        help=f'how many overlapping analysis and synthesis windows will be used, default is {DEFAULT_OVERLAP}')
+    parser.add_argument(
+        '-w', '--window',
+        choices=WINDOW_TYPES,
+        default=DEFAULT_WINDOW,
+        help=f'what window shape will be used for analysis and synthesis. Available options are: ', '.join(WINDOW_TYPES))
     args = parser.parse_args()
     perform_stretch(args)

--- a/python/nessstretch.py
+++ b/python/nessstretch.py
@@ -48,7 +48,7 @@ def render(infile, outfile, playback_rate, overlap, window):
     for channel in range(n_channels):
         print(f'processing channel {channel+1}')
         input_channel = normalized_input_data[:, channel]
-        output = fancy_stretch(input_channel, playback_rate, overlap=overlap, window=window)
+        output.append(fancy_stretch(input_channel, playback_rate, overlap=overlap, window=window))
     # Transpose array: see https://github.com/bastibe/SoundFile/issues/203
     audio_array = np.int16(np.array(output).T * max_dtype_val)
     print('writing audio. . .')
@@ -82,6 +82,6 @@ if __name__ == "__main__":
         '-w', '--window',
         choices=WINDOW_TYPES,
         default=DEFAULT_WINDOW,
-        help=f'what window shape will be used for analysis and synthesis. Available options are: ', '.join(WINDOW_TYPES))
+        help=f"what window shape will be used for analysis and synthesis. Available options are: {', '.join(WINDOW_TYPES)}")
     args = parser.parse_args()
     perform_stretch(args)


### PR DESCRIPTION
In this refactor, the main change is using frame-by-frame analysis and resynthesis using `rfft` and `irfft` instead of `stft` and `istft`. This method doesn't require generating the huge 2d arrays, so longer outputs are possible with no significant RAM pressure. Rather than generating interpolated 2d arrays, it now uses `interp1d` to interpolate between analysis frames.

In addition to this refactoring, I also exposed the window type and overlap factor as parameters.

To my ears, there are some audio differences in the output. I think it sounds good, but looking forward to hearing what @spluta and Alex think about it. Perhaps rather than replacing the original mode, this should be included as a separate algorithm?