### PR TITLE
replace runInTerminal with unixCmd

### DIFF
--- a/supercollider/Classes/TimeStretch.sc
+++ b/supercollider/Classes/TimeStretch.sc
@@ -315,7 +315,7 @@ TimeStretch {
 
 		chanArray.do{|chanNum, i2|
 			TimeStretch.mkStretchTemp(fileName++"_"++chanNum++".scd", inFile, durMult, chanNum, splits, filterOrder, fftType);
-			AppClock.sched((1), {("sclang "++fileName++"_"++chanNum++".scd").postln.runInTerminal});
+            AppClock.sched((1), {("sclang "++fileName++"_"++chanNum++".scd").postln.unixCmd});
 		}
 	}
 


### PR DESCRIPTION
Hi ! 

On Linux, the `runInTerminal` method will most likely emit an error about not being able to find `xterm` (see https://github.com/supercollider/supercollider/pull/4994). Therefore, this is a PR with an alternative suggestion: `unixCmd`. This will always work :) 