### PR TITLE
supercollider: stretch2PlusChannels: escape .scd path

### DIFF
--- a/supercollider/Classes/TimeStretch.sc
+++ b/supercollider/Classes/TimeStretch.sc
@@ -314,8 +314,10 @@ TimeStretch {
 		if(chanArray==nil){chanArray = Array.fill(SoundFile.openRead(inFile).numChannels, {|i| i})};
 
 		chanArray.do{|chanNum, i2|
-			TimeStretch.mkStretchTemp(fileName++"_"++chanNum++".scd", inFile, durMult, chanNum, splits, filterOrder, fftType);
-			AppClock.sched((1), {("sclang "++fileName++"_"++chanNum++".scd").postln.runInTerminal});
+			var scdPath = fileName ++ "_" ++ chanNum ++ ".scd";
+			var escapedScdPath = thisProcess.platform.formatPathForCmdLine(scdPath);
+			TimeStretch.mkStretchTemp(scdPath, inFile, durMult, chanNum, splits, filterOrder, fftType);
+			AppClock.sched(1) { ("sclang " ++ escapedScdPath).postln.runInTerminal };
 		}
 	}
 


### PR DESCRIPTION
Escape .scd path to prevent errors when path includes spaces.

It affects only *stretch2PlusChannels as it's the only method I found that calls .runInTerminal.
I tested it only on Linux, maybe it was a problem only there?

### Issue
```supercollider
TimeStretch.stretch2PlusChannels("Bieber With Spaces", 100, [0,1], 9);
// a new sclang instance spawns in a terminal, but fails with:
// >  file "Bieber" does not exist.
// (instead of "Bieber With Spaces"
```

This PR solves it by calling `thisProcess.formatPathForCmdLine(scdPath)` before passing it to terminal.


